### PR TITLE
feat: Help center support (articles & collections)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ gleap tickets create "Add dark mode" --type FEATURE_REQUEST --priority LOW --tag
 gleap tickets update <ID> --status DONE
 gleap tickets update <ID> --priority HIGH --title "New title"
 
+# Delete a ticket
+gleap tickets delete <ID>
+
 # View captured logs
 gleap tickets logs console <ID>
 gleap tickets logs network <ID>
@@ -110,6 +113,9 @@ gleap messages list --ticket <ID> --limit 5
 
 # Add an internal note (team only)
 gleap messages note --ticket <ID> "Root cause identified in auth service."
+
+# Delete a message
+gleap messages delete <ID>
 
 # Reply to the customer
 gleap messages reply --ticket <ID> "We've deployed a fix. Please try again."
@@ -130,8 +136,8 @@ gleap -vvv tickets list     # + full response body always
 | Resource | Operations |
 |----------|-----------|
 | **Auth** | login, logout, status |
-| **Tickets** | list, get, search, create, update, logs (console, network, activity) |
-| **Messages** | list, note (internal), reply (comment) |
+| **Tickets** | list, get, search, create, update, delete, logs (console, network, activity) |
+| **Messages** | list, note (internal), reply (comment), delete |
 
 The Gleap API has many more endpoints (help center, engagements, surveys, statistics, sessions, etc.) that are not yet implemented. Contributions welcome.
 
@@ -185,8 +191,8 @@ src/
 │   └── message.rs
 └── commands/            # Command handlers
     ├── auth.rs
-    ├── tickets/         # list, get, search, create, update, logs
-    └── messages/        # list, note, reply
+    ├── tickets/         # list, get, search, create, update, delete, logs
+    └── messages/        # list, note, reply, delete
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -141,6 +141,30 @@ gleap collections update <ID> --title "Updated Title"
 gleap collections delete <ID>
 ```
 
+### Articles (Help Center)
+
+```bash
+# List articles in a collection
+gleap articles list --collection <ID>
+
+# Get a single article
+gleap articles get --collection <ID> <ARTICLE_ID>
+
+# Create an article (defaults to draft, English)
+gleap articles create --collection <ID> --title "Getting Started" --content-file content.json
+gleap articles create --collection <ID> --title "Erste Schritte" --language de --published
+
+# Update an article
+gleap articles update --collection <ID> <ARTICLE_ID> --title "Updated Title"
+gleap articles update --collection <ID> <ARTICLE_ID> --content-file updated.json --published true
+
+# Delete an article
+gleap articles delete --collection <ID> <ARTICLE_ID>
+
+# Move an article to a different collection
+gleap articles move --collection <ID> <ARTICLE_ID> --to <TARGET_COLLECTION_ID>
+```
+
 ## Verbose Output
 
 Use `-v` flags globally for debugging:
@@ -159,6 +183,7 @@ gleap -vvv tickets list     # + full response body always
 | **Tickets** | list, get, search, create, update, delete, logs (console, network, activity) |
 | **Messages** | list, note (internal), reply (comment), delete |
 | **Collections** | list, get, create, update, delete |
+| **Articles** | list, get, create, update, delete, move |
 
 The Gleap API has many more endpoints (engagements, surveys, statistics, sessions, etc.) that are not yet implemented. Contributions welcome.
 
@@ -203,21 +228,25 @@ src/
 │   ├── tickets.rs
 │   ├── messages.rs
 │   ├── collections.rs
+│   ├── articles.rs
 │   └── shared.rs        # Shared args (pagination)
 ├── client/              # Gleap API HTTP client
 │   ├── mod.rs           # GleapClient (auth, request helpers, verbose logging)
 │   ├── tickets.rs
 │   ├── messages.rs
-│   └── collections.rs
+│   ├── collections.rs
+│   └── articles.rs
 ├── models/              # Request/response types
 │   ├── ticket.rs
 │   ├── message.rs
-│   └── collection.rs
+│   ├── collection.rs
+│   └── article.rs
 └── commands/            # Command handlers
     ├── auth.rs
     ├── tickets/         # list, get, search, create, update, delete, logs
     ├── messages/        # list, note, reply, delete
-    └── collections/     # list, get, create, update, delete
+    ├── collections/     # list, get, create, update, delete
+    └── articles/        # list, get, create, update, delete, move
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -121,6 +121,26 @@ gleap messages delete <ID>
 gleap messages reply --ticket <ID> "We've deployed a fix. Please try again."
 ```
 
+### Collections (Help Center)
+
+```bash
+# List all collections
+gleap collections list
+
+# Get a single collection
+gleap collections get <ID>
+
+# Create a collection
+gleap collections create --title "Getting Started"
+gleap collections create --title "FAQ" --description "Frequently asked questions"
+
+# Update a collection
+gleap collections update <ID> --title "Updated Title"
+
+# Delete a collection
+gleap collections delete <ID>
+```
+
 ## Verbose Output
 
 Use `-v` flags globally for debugging:
@@ -138,8 +158,9 @@ gleap -vvv tickets list     # + full response body always
 | **Auth** | login, logout, status |
 | **Tickets** | list, get, search, create, update, delete, logs (console, network, activity) |
 | **Messages** | list, note (internal), reply (comment), delete |
+| **Collections** | list, get, create, update, delete |
 
-The Gleap API has many more endpoints (help center, engagements, surveys, statistics, sessions, etc.) that are not yet implemented. Contributions welcome.
+The Gleap API has many more endpoints (engagements, surveys, statistics, sessions, etc.) that are not yet implemented. Contributions welcome.
 
 ### References
 
@@ -181,18 +202,22 @@ src/
 │   ├── auth.rs
 │   ├── tickets.rs
 │   ├── messages.rs
+│   ├── collections.rs
 │   └── shared.rs        # Shared args (pagination)
 ├── client/              # Gleap API HTTP client
 │   ├── mod.rs           # GleapClient (auth, request helpers, verbose logging)
 │   ├── tickets.rs
-│   └── messages.rs
+│   ├── messages.rs
+│   └── collections.rs
 ├── models/              # Request/response types
 │   ├── ticket.rs
-│   └── message.rs
+│   ├── message.rs
+│   └── collection.rs
 └── commands/            # Command handlers
     ├── auth.rs
     ├── tickets/         # list, get, search, create, update, delete, logs
-    └── messages/        # list, note, reply, delete
+    ├── messages/        # list, note, reply, delete
+    └── collections/     # list, get, create, update, delete
 ```
 
 ## License

--- a/src/cli/articles.rs
+++ b/src/cli/articles.rs
@@ -1,0 +1,107 @@
+use clap::Subcommand;
+
+use super::shared::Pagination;
+
+#[derive(Subcommand, Debug)]
+pub enum ArticlesAction {
+    /// List articles in a collection
+    List {
+        /// Collection ID
+        #[arg(long)]
+        collection: String,
+
+        #[command(flatten)]
+        pagination: Pagination,
+    },
+
+    /// Get a single article by ID
+    Get {
+        /// Article ID
+        id: String,
+
+        /// Collection ID
+        #[arg(long)]
+        collection: String,
+    },
+
+    /// Create a new article
+    Create {
+        /// Collection ID
+        #[arg(long)]
+        collection: String,
+
+        /// Article title
+        #[arg(long)]
+        title: String,
+
+        /// Path to a JSON file containing Tiptap/ProseMirror content
+        #[arg(long)]
+        content_file: Option<String>,
+
+        /// Language code for title and content (default: en)
+        #[arg(long, default_value = "en")]
+        language: String,
+
+        /// Publish the article (default: draft)
+        #[arg(long)]
+        published: bool,
+
+        /// Comma-separated tags
+        #[arg(long)]
+        tags: Option<String>,
+    },
+
+    /// Update an existing article
+    Update {
+        /// Article ID
+        id: String,
+
+        /// Collection ID
+        #[arg(long)]
+        collection: String,
+
+        /// New title
+        #[arg(long)]
+        title: Option<String>,
+
+        /// Path to a JSON file containing updated Tiptap/ProseMirror content
+        #[arg(long)]
+        content_file: Option<String>,
+
+        /// Language code for title and content (default: en)
+        #[arg(long, default_value = "en")]
+        language: String,
+
+        /// Publish the article
+        #[arg(long)]
+        published: Option<bool>,
+
+        /// Comma-separated tags
+        #[arg(long)]
+        tags: Option<String>,
+    },
+
+    /// Delete an article
+    Delete {
+        /// Article ID
+        id: String,
+
+        /// Collection ID
+        #[arg(long)]
+        collection: String,
+    },
+
+    /// Move an article to a different collection
+    Move {
+        /// Article ID
+        id: String,
+
+        /// Current collection ID
+        #[arg(long)]
+        collection: String,
+
+        /// Target collection ID
+        #[arg(long)]
+        to: String,
+    },
+}

--- a/src/cli/collections.rs
+++ b/src/cli/collections.rs
@@ -1,0 +1,49 @@
+use clap::Subcommand;
+
+use super::shared::Pagination;
+
+#[derive(Subcommand, Debug)]
+pub enum CollectionsAction {
+    /// List all collections
+    List {
+        #[command(flatten)]
+        pagination: Pagination,
+    },
+
+    /// Get a single collection by ID
+    Get {
+        /// Collection ID
+        id: String,
+    },
+
+    /// Create a new collection
+    Create {
+        /// Collection title
+        #[arg(long)]
+        title: String,
+
+        /// Collection description
+        #[arg(long)]
+        description: Option<String>,
+    },
+
+    /// Update an existing collection
+    Update {
+        /// Collection ID
+        id: String,
+
+        /// New title
+        #[arg(long)]
+        title: Option<String>,
+
+        /// New description
+        #[arg(long)]
+        description: Option<String>,
+    },
+
+    /// Delete a collection
+    Delete {
+        /// Collection ID
+        id: String,
+    },
+}

--- a/src/cli/messages.rs
+++ b/src/cli/messages.rs
@@ -24,6 +24,12 @@ pub enum MessagesAction {
         text: String,
     },
 
+    /// Delete a message
+    Delete {
+        /// Message ID
+        id: String,
+    },
+
     /// Add a comment reply to a ticket
     Reply {
         /// Ticket ID

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod collections;
 pub mod messages;
 pub mod shared;
 pub mod tickets;
@@ -6,6 +7,7 @@ pub mod tickets;
 use clap::{ArgAction, Parser, Subcommand};
 
 pub use auth::AuthAction;
+pub use collections::CollectionsAction;
 pub use messages::MessagesAction;
 pub use tickets::{LogsAction, TicketsAction};
 
@@ -43,5 +45,11 @@ pub enum Domain {
     Messages {
         #[command(subcommand)]
         action: MessagesAction,
+    },
+
+    /// Manage help center collections
+    Collections {
+        #[command(subcommand)]
+        action: CollectionsAction,
     },
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,4 @@
+pub mod articles;
 pub mod auth;
 pub mod collections;
 pub mod messages;
@@ -6,6 +7,7 @@ pub mod tickets;
 
 use clap::{ArgAction, Parser, Subcommand};
 
+pub use articles::ArticlesAction;
 pub use auth::AuthAction;
 pub use collections::CollectionsAction;
 pub use messages::MessagesAction;
@@ -51,5 +53,11 @@ pub enum Domain {
     Collections {
         #[command(subcommand)]
         action: CollectionsAction,
+    },
+
+    /// Manage help center articles
+    Articles {
+        #[command(subcommand)]
+        action: ArticlesAction,
     },
 }

--- a/src/cli/tickets.rs
+++ b/src/cli/tickets.rs
@@ -82,6 +82,12 @@ pub enum TicketsAction {
         title: Option<String>,
     },
 
+    /// Delete a ticket
+    Delete {
+        /// Ticket ID
+        id: String,
+    },
+
     /// View logs captured with a ticket
     Logs {
         #[command(subcommand)]

--- a/src/client/articles.rs
+++ b/src/client/articles.rs
@@ -1,0 +1,106 @@
+use crate::error::AppError;
+use crate::models::article::{Article, ArticleFilters};
+
+use super::GleapClient;
+
+pub struct ArticlesClient<'a> {
+    client: &'a GleapClient,
+}
+
+impl<'a> ArticlesClient<'a> {
+    pub(crate) fn new(client: &'a GleapClient) -> Self {
+        Self { client }
+    }
+
+    fn base_path(collection_id: &str) -> String {
+        format!("/helpcenter/collections/{}/articles", collection_id)
+    }
+
+    fn article_path(collection_id: &str, article_id: &str) -> String {
+        format!(
+            "/helpcenter/collections/{}/articles/{}",
+            collection_id, article_id
+        )
+    }
+
+    /// List articles in a collection.
+    pub async fn list(
+        &self,
+        collection_id: &str,
+        filters: &ArticleFilters,
+    ) -> Result<Vec<Article>, AppError> {
+        let mut request = self.client.get(&Self::base_path(collection_id));
+
+        if let Some(limit) = filters.limit {
+            request = request.query(&[("limit", &limit.to_string())]);
+        }
+        if let Some(skip) = filters.skip {
+            request = request.query(&[("skip", &skip.to_string())]);
+        }
+
+        self.client.send_and_parse(request).await
+    }
+
+    /// Get a single article by ID.
+    pub async fn get(&self, collection_id: &str, article_id: &str) -> Result<Article, AppError> {
+        let request = self
+            .client
+            .get(&Self::article_path(collection_id, article_id));
+        self.client.send_and_parse(request).await
+    }
+
+    /// Create a new article in a collection.
+    pub async fn create(
+        &self,
+        collection_id: &str,
+        body: serde_json::Value,
+    ) -> Result<Article, AppError> {
+        let request = self
+            .client
+            .post(&Self::base_path(collection_id))
+            .json(&body);
+        self.client.send_and_parse(request).await
+    }
+
+    /// Update an article by ID.
+    pub async fn update(
+        &self,
+        collection_id: &str,
+        article_id: &str,
+        body: serde_json::Value,
+    ) -> Result<Article, AppError> {
+        let request = self
+            .client
+            .put(&Self::article_path(collection_id, article_id))
+            .json(&body);
+        self.client.send_and_parse(request).await
+    }
+
+    /// Delete an article by ID.
+    pub async fn delete(
+        &self,
+        collection_id: &str,
+        article_id: &str,
+    ) -> Result<serde_json::Value, AppError> {
+        let request = self
+            .client
+            .delete(&Self::article_path(collection_id, article_id));
+        self.client.send_and_parse(request).await
+    }
+
+    /// Move an article to a different collection.
+    pub async fn move_article(
+        &self,
+        collection_id: &str,
+        article_id: &str,
+        new_collection_id: &str,
+    ) -> Result<Article, AppError> {
+        let path = format!(
+            "/helpcenter/collections/{}/articles/{}/move",
+            collection_id, article_id
+        );
+        let body = serde_json::json!({ "newCollectionId": new_collection_id });
+        let request = self.client.put(&path).json(&body);
+        self.client.send_and_parse(request).await
+    }
+}

--- a/src/client/collections.rs
+++ b/src/client/collections.rs
@@ -1,0 +1,57 @@
+use crate::error::AppError;
+use crate::models::collection::{Collection, CollectionFilters};
+
+use super::GleapClient;
+
+pub struct CollectionsClient<'a> {
+    client: &'a GleapClient,
+}
+
+impl<'a> CollectionsClient<'a> {
+    pub(crate) fn new(client: &'a GleapClient) -> Self {
+        Self { client }
+    }
+
+    /// List all collections with optional filters.
+    pub async fn list(&self, filters: &CollectionFilters) -> Result<Vec<Collection>, AppError> {
+        let mut request = self.client.get("/helpcenter/collections");
+
+        if let Some(limit) = filters.limit {
+            request = request.query(&[("limit", &limit.to_string())]);
+        }
+        if let Some(skip) = filters.skip {
+            request = request.query(&[("skip", &skip.to_string())]);
+        }
+
+        self.client.send_and_parse(request).await
+    }
+
+    /// Get a single collection by ID.
+    pub async fn get(&self, id: &str) -> Result<Collection, AppError> {
+        let request = self.client.get(&format!("/helpcenter/collections/{}", id));
+        self.client.send_and_parse(request).await
+    }
+
+    /// Create a new collection.
+    pub async fn create(&self, body: serde_json::Value) -> Result<Collection, AppError> {
+        let request = self.client.post("/helpcenter/collections").json(&body);
+        self.client.send_and_parse(request).await
+    }
+
+    /// Update a collection by ID.
+    pub async fn update(&self, id: &str, body: serde_json::Value) -> Result<Collection, AppError> {
+        let request = self
+            .client
+            .put(&format!("/helpcenter/collections/{}", id))
+            .json(&body);
+        self.client.send_and_parse(request).await
+    }
+
+    /// Delete a collection by ID.
+    pub async fn delete(&self, id: &str) -> Result<serde_json::Value, AppError> {
+        let request = self
+            .client
+            .delete(&format!("/helpcenter/collections/{}", id));
+        self.client.send_and_parse(request).await
+    }
+}

--- a/src/client/messages.rs
+++ b/src/client/messages.rs
@@ -53,6 +53,12 @@ impl<'a> MessagesClient<'a> {
         self.create(&request).await
     }
 
+    /// Delete a message by ID.
+    pub async fn delete(&self, message_id: &str) -> Result<serde_json::Value, AppError> {
+        let request = self.client.delete(&format!("/messages/{}", message_id));
+        self.client.send_and_parse(request).await
+    }
+
     /// Convenience: create a comment reply on a ticket.
     pub async fn create_comment(&self, ticket_id: &str, text: &str) -> Result<Message, AppError> {
         let request = CreateMessageRequest {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,6 +1,8 @@
+mod collections;
 mod messages;
 mod tickets;
 
+pub use collections::CollectionsClient;
 pub use messages::MessagesClient;
 pub use tickets::TicketsClient;
 
@@ -59,6 +61,10 @@ impl GleapClient {
 
     pub fn messages(&self) -> MessagesClient<'_> {
         MessagesClient::new(self)
+    }
+
+    pub fn collections(&self) -> CollectionsClient<'_> {
+        CollectionsClient::new(self)
     }
 
     /// Build a GET request with auth headers pre-applied.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -97,6 +97,18 @@ impl GleapClient {
             .header("project", &self.config.project_id)
     }
 
+    /// Build a DELETE request with auth headers pre-applied.
+    pub(crate) fn delete(&self, path: &str) -> reqwest::RequestBuilder {
+        let url = format!("{}{}", self.config.base_url, path);
+        if self.verbose >= 1 {
+            eprintln!("> DELETE {url}");
+        }
+        self.http
+            .delete(&url)
+            .bearer_auth(&self.config.api_key)
+            .header("project", &self.config.project_id)
+    }
+
     /// Send a request and handle common error responses.
     pub(crate) async fn send(
         &self,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,7 +1,9 @@
+mod articles;
 mod collections;
 mod messages;
 mod tickets;
 
+pub use articles::ArticlesClient;
 pub use collections::CollectionsClient;
 pub use messages::MessagesClient;
 pub use tickets::TicketsClient;
@@ -65,6 +67,10 @@ impl GleapClient {
 
     pub fn collections(&self) -> CollectionsClient<'_> {
         CollectionsClient::new(self)
+    }
+
+    pub fn articles(&self) -> ArticlesClient<'_> {
+        ArticlesClient::new(self)
     }
 
     /// Build a GET request with auth headers pre-applied.

--- a/src/client/tickets.rs
+++ b/src/client/tickets.rs
@@ -79,6 +79,12 @@ impl<'a> TicketsClient<'a> {
         self.client.send_and_parse(request).await
     }
 
+    /// Delete a ticket by ID.
+    pub async fn delete(&self, ticket_id: &str) -> Result<serde_json::Value, AppError> {
+        let request = self.client.delete(&format!("/tickets/{}", ticket_id));
+        self.client.send_and_parse(request).await
+    }
+
     /// Get activity logs for a ticket.
     pub async fn activity_logs(&self, ticket_id: &str) -> Result<serde_json::Value, AppError> {
         let request = self

--- a/src/commands/articles/create.rs
+++ b/src/commands/articles/create.rs
@@ -1,0 +1,52 @@
+use gleap::client::GleapClient;
+use gleap::error::AppError;
+
+pub async fn run(
+    client: &GleapClient,
+    collection_id: &str,
+    title: &str,
+    content_file: Option<String>,
+    language: &str,
+    published: bool,
+    tags: Option<String>,
+) -> Result<(), AppError> {
+    let mut fields = serde_json::Map::new();
+
+    // Wrap title in language key: {"title": {"en": "..."}}
+    fields.insert("title".into(), serde_json::json!({ language: title }));
+
+    // Read and wrap content file if provided
+    if let Some(ref path) = content_file {
+        let raw = std::fs::read_to_string(path).map_err(|e| {
+            AppError::Config(format!("Failed to read content file '{}': {}", path, e))
+        })?;
+        let content_json: serde_json::Value = serde_json::from_str(&raw).map_err(|e| {
+            AppError::Config(format!("Invalid JSON in content file '{}': {}", path, e))
+        })?;
+        fields.insert(
+            "content".into(),
+            serde_json::json!({ language: content_json }),
+        );
+    }
+
+    if published {
+        fields.insert("isDraft".into(), serde_json::Value::Bool(false));
+    }
+
+    if let Some(tags) = tags {
+        let tag_list: Vec<serde_json::Value> = tags
+            .split(',')
+            .map(|t| serde_json::Value::String(t.trim().to_string()))
+            .filter(|t| t.as_str() != Some(""))
+            .collect();
+        fields.insert("tags".into(), serde_json::Value::Array(tag_list));
+    }
+
+    let article = client
+        .articles()
+        .create(collection_id, serde_json::Value::Object(fields))
+        .await?;
+    let json = serde_json::to_string_pretty(&article)?;
+    println!("{}", json);
+    Ok(())
+}

--- a/src/commands/articles/delete.rs
+++ b/src/commands/articles/delete.rs
@@ -1,0 +1,13 @@
+use gleap::client::GleapClient;
+use gleap::error::AppError;
+
+pub async fn run(
+    client: &GleapClient,
+    collection_id: &str,
+    article_id: &str,
+) -> Result<(), AppError> {
+    let result = client.articles().delete(collection_id, article_id).await?;
+    let json = serde_json::to_string_pretty(&result)?;
+    println!("{}", json);
+    Ok(())
+}

--- a/src/commands/articles/get.rs
+++ b/src/commands/articles/get.rs
@@ -1,0 +1,13 @@
+use gleap::client::GleapClient;
+use gleap::error::AppError;
+
+pub async fn run(
+    client: &GleapClient,
+    collection_id: &str,
+    article_id: &str,
+) -> Result<(), AppError> {
+    let article = client.articles().get(collection_id, article_id).await?;
+    let json = serde_json::to_string_pretty(&article)?;
+    println!("{}", json);
+    Ok(())
+}

--- a/src/commands/articles/list.rs
+++ b/src/commands/articles/list.rs
@@ -1,0 +1,19 @@
+use gleap::client::GleapClient;
+use gleap::error::AppError;
+use gleap::models::article::ArticleFilters;
+
+pub async fn run(
+    client: &GleapClient,
+    collection_id: &str,
+    limit: u64,
+    skip: u64,
+) -> Result<(), AppError> {
+    let filters = ArticleFilters {
+        limit: Some(limit),
+        skip: Some(skip),
+    };
+    let articles = client.articles().list(collection_id, &filters).await?;
+    let json = serde_json::to_string_pretty(&articles)?;
+    println!("{}", json);
+    Ok(())
+}

--- a/src/commands/articles/mod.rs
+++ b/src/commands/articles/mod.rs
@@ -1,0 +1,6 @@
+pub mod create;
+pub mod delete;
+pub mod get;
+pub mod list;
+pub mod move_article;
+pub mod update;

--- a/src/commands/articles/move_article.rs
+++ b/src/commands/articles/move_article.rs
@@ -1,0 +1,17 @@
+use gleap::client::GleapClient;
+use gleap::error::AppError;
+
+pub async fn run(
+    client: &GleapClient,
+    collection_id: &str,
+    article_id: &str,
+    to_collection_id: &str,
+) -> Result<(), AppError> {
+    let article = client
+        .articles()
+        .move_article(collection_id, article_id, to_collection_id)
+        .await?;
+    let json = serde_json::to_string_pretty(&article)?;
+    println!("{}", json);
+    Ok(())
+}

--- a/src/commands/articles/update.rs
+++ b/src/commands/articles/update.rs
@@ -1,0 +1,68 @@
+use gleap::client::GleapClient;
+use gleap::error::AppError;
+
+pub struct UpdateParams {
+    pub title: Option<String>,
+    pub content_file: Option<String>,
+    pub language: String,
+    pub published: Option<bool>,
+    pub tags: Option<String>,
+}
+
+pub async fn run(
+    client: &GleapClient,
+    collection_id: &str,
+    article_id: &str,
+    params: UpdateParams,
+) -> Result<(), AppError> {
+    let UpdateParams {
+        title,
+        content_file,
+        language,
+        published,
+        tags,
+    } = params;
+    let lang = &language;
+    let mut fields = serde_json::Map::new();
+
+    if let Some(title) = title {
+        fields.insert("title".into(), serde_json::json!({ lang: title }));
+    }
+
+    if let Some(ref path) = content_file {
+        let raw = std::fs::read_to_string(path).map_err(|e| {
+            AppError::Config(format!("Failed to read content file '{}': {}", path, e))
+        })?;
+        let content_json: serde_json::Value = serde_json::from_str(&raw).map_err(|e| {
+            AppError::Config(format!("Invalid JSON in content file '{}': {}", path, e))
+        })?;
+        fields.insert("content".into(), serde_json::json!({ lang: content_json }));
+    }
+
+    if let Some(published) = published {
+        fields.insert("isDraft".into(), serde_json::Value::Bool(!published));
+    }
+
+    if let Some(tags) = tags {
+        let tag_list: Vec<serde_json::Value> = tags
+            .split(',')
+            .map(|t| serde_json::Value::String(t.trim().to_string()))
+            .filter(|t| t.as_str() != Some(""))
+            .collect();
+        fields.insert("tags".into(), serde_json::Value::Array(tag_list));
+    }
+
+    if fields.is_empty() {
+        return Err(AppError::Config(
+            "No fields to update. Provide --title, --content-file, --published, or --tags.".into(),
+        ));
+    }
+
+    let article = client
+        .articles()
+        .update(collection_id, article_id, serde_json::Value::Object(fields))
+        .await?;
+    let json = serde_json::to_string_pretty(&article)?;
+    println!("{}", json);
+    Ok(())
+}

--- a/src/commands/collections/create.rs
+++ b/src/commands/collections/create.rs
@@ -1,0 +1,23 @@
+use gleap::client::GleapClient;
+use gleap::error::AppError;
+
+pub async fn run(
+    client: &GleapClient,
+    title: &str,
+    description: Option<String>,
+) -> Result<(), AppError> {
+    let mut fields = serde_json::Map::new();
+    fields.insert("title".into(), serde_json::Value::String(title.into()));
+
+    if let Some(description) = description {
+        fields.insert("description".into(), serde_json::Value::String(description));
+    }
+
+    let collection = client
+        .collections()
+        .create(serde_json::Value::Object(fields))
+        .await?;
+    let json = serde_json::to_string_pretty(&collection)?;
+    println!("{}", json);
+    Ok(())
+}

--- a/src/commands/collections/delete.rs
+++ b/src/commands/collections/delete.rs
@@ -1,0 +1,9 @@
+use gleap::client::GleapClient;
+use gleap::error::AppError;
+
+pub async fn run(client: &GleapClient, id: &str) -> Result<(), AppError> {
+    let result = client.collections().delete(id).await?;
+    let json = serde_json::to_string_pretty(&result)?;
+    println!("{}", json);
+    Ok(())
+}

--- a/src/commands/collections/get.rs
+++ b/src/commands/collections/get.rs
@@ -1,0 +1,9 @@
+use gleap::client::GleapClient;
+use gleap::error::AppError;
+
+pub async fn run(client: &GleapClient, id: &str) -> Result<(), AppError> {
+    let collection = client.collections().get(id).await?;
+    let json = serde_json::to_string_pretty(&collection)?;
+    println!("{}", json);
+    Ok(())
+}

--- a/src/commands/collections/list.rs
+++ b/src/commands/collections/list.rs
@@ -1,0 +1,14 @@
+use gleap::client::GleapClient;
+use gleap::error::AppError;
+use gleap::models::collection::CollectionFilters;
+
+pub async fn run(client: &GleapClient, limit: u64, skip: u64) -> Result<(), AppError> {
+    let filters = CollectionFilters {
+        limit: Some(limit),
+        skip: Some(skip),
+    };
+    let collections = client.collections().list(&filters).await?;
+    let json = serde_json::to_string_pretty(&collections)?;
+    println!("{}", json);
+    Ok(())
+}

--- a/src/commands/collections/mod.rs
+++ b/src/commands/collections/mod.rs
@@ -1,0 +1,5 @@
+pub mod create;
+pub mod delete;
+pub mod get;
+pub mod list;
+pub mod update;

--- a/src/commands/collections/update.rs
+++ b/src/commands/collections/update.rs
@@ -1,0 +1,32 @@
+use gleap::client::GleapClient;
+use gleap::error::AppError;
+
+pub async fn run(
+    client: &GleapClient,
+    id: &str,
+    title: Option<String>,
+    description: Option<String>,
+) -> Result<(), AppError> {
+    let mut fields = serde_json::Map::new();
+
+    if let Some(title) = title {
+        fields.insert("title".into(), serde_json::Value::String(title));
+    }
+    if let Some(description) = description {
+        fields.insert("description".into(), serde_json::Value::String(description));
+    }
+
+    if fields.is_empty() {
+        return Err(AppError::Config(
+            "No fields to update. Provide --title or --description.".into(),
+        ));
+    }
+
+    let collection = client
+        .collections()
+        .update(id, serde_json::Value::Object(fields))
+        .await?;
+    let json = serde_json::to_string_pretty(&collection)?;
+    println!("{}", json);
+    Ok(())
+}

--- a/src/commands/messages/delete.rs
+++ b/src/commands/messages/delete.rs
@@ -1,0 +1,9 @@
+use gleap::client::GleapClient;
+use gleap::error::AppError;
+
+pub async fn run(client: &GleapClient, id: &str) -> Result<(), AppError> {
+    let result = client.messages().delete(id).await?;
+    let json = serde_json::to_string_pretty(&result)?;
+    println!("{}", json);
+    Ok(())
+}

--- a/src/commands/messages/mod.rs
+++ b/src/commands/messages/mod.rs
@@ -1,3 +1,4 @@
+pub mod delete;
 pub mod list;
 pub mod note;
 pub mod reply;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod articles;
 pub mod auth;
 pub mod collections;
 pub mod messages;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod auth;
+pub mod collections;
 pub mod messages;
 pub mod tickets;

--- a/src/commands/tickets/delete.rs
+++ b/src/commands/tickets/delete.rs
@@ -1,0 +1,9 @@
+use gleap::client::GleapClient;
+use gleap::error::AppError;
+
+pub async fn run(client: &GleapClient, id: &str) -> Result<(), AppError> {
+    let result = client.tickets().delete(id).await?;
+    let json = serde_json::to_string_pretty(&result)?;
+    println!("{}", json);
+    Ok(())
+}

--- a/src/commands/tickets/mod.rs
+++ b/src/commands/tickets/mod.rs
@@ -1,6 +1,7 @@
 pub mod activity_logs;
 pub mod console_logs;
 pub mod create;
+pub mod delete;
 pub mod get;
 pub mod list;
 pub mod network_logs;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ mod commands;
 use gleap::client::GleapClient;
 use gleap::error::AppError;
 
-use cli::{AuthAction, Cli, Domain, LogsAction, MessagesAction, TicketsAction};
+use cli::{AuthAction, Cli, CollectionsAction, Domain, LogsAction, MessagesAction, TicketsAction};
 
 #[tokio::main]
 async fn main() {
@@ -104,6 +104,23 @@ async fn run() -> Result<(), AppError> {
             }
             MessagesAction::Reply { ticket, text } => {
                 commands::messages::reply::run(&client, &ticket, &text).await
+            }
+        },
+        Domain::Collections { action } => match action {
+            CollectionsAction::List { pagination } => {
+                commands::collections::list::run(&client, pagination.limit, pagination.skip).await
+            }
+            CollectionsAction::Get { id } => commands::collections::get::run(&client, &id).await,
+            CollectionsAction::Create { title, description } => {
+                commands::collections::create::run(&client, &title, description).await
+            }
+            CollectionsAction::Update {
+                id,
+                title,
+                description,
+            } => commands::collections::update::run(&client, &id, title, description).await,
+            CollectionsAction::Delete { id } => {
+                commands::collections::delete::run(&client, &id).await
             }
         },
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,7 @@ async fn run() -> Result<(), AppError> {
                 priority,
                 title,
             } => commands::tickets::update::run(&client, &id, status, priority, title).await,
+            TicketsAction::Delete { id } => commands::tickets::delete::run(&client, &id).await,
             TicketsAction::Logs { action } => match action {
                 LogsAction::Console { id } => {
                     commands::tickets::console_logs::run(&client, &id).await
@@ -97,6 +98,7 @@ async fn run() -> Result<(), AppError> {
                 commands::messages::list::run(&client, &ticket, pagination.limit, pagination.skip)
                     .await
             }
+            MessagesAction::Delete { id } => commands::messages::delete::run(&client, &id).await,
             MessagesAction::Note { ticket, text } => {
                 commands::messages::note::run(&client, &ticket, &text).await
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,10 @@ mod commands;
 use gleap::client::GleapClient;
 use gleap::error::AppError;
 
-use cli::{AuthAction, Cli, CollectionsAction, Domain, LogsAction, MessagesAction, TicketsAction};
+use cli::{
+    ArticlesAction, AuthAction, Cli, CollectionsAction, Domain, LogsAction, MessagesAction,
+    TicketsAction,
+};
 
 #[tokio::main]
 async fn main() {
@@ -121,6 +124,66 @@ async fn run() -> Result<(), AppError> {
             } => commands::collections::update::run(&client, &id, title, description).await,
             CollectionsAction::Delete { id } => {
                 commands::collections::delete::run(&client, &id).await
+            }
+        },
+        Domain::Articles { action } => match action {
+            ArticlesAction::List {
+                collection,
+                pagination,
+            } => {
+                commands::articles::list::run(
+                    &client,
+                    &collection,
+                    pagination.limit,
+                    pagination.skip,
+                )
+                .await
+            }
+            ArticlesAction::Get { id, collection } => {
+                commands::articles::get::run(&client, &collection, &id).await
+            }
+            ArticlesAction::Create {
+                collection,
+                title,
+                content_file,
+                language,
+                published,
+                tags,
+            } => {
+                commands::articles::create::run(
+                    &client,
+                    &collection,
+                    &title,
+                    content_file,
+                    &language,
+                    published,
+                    tags,
+                )
+                .await
+            }
+            ArticlesAction::Update {
+                id,
+                collection,
+                title,
+                content_file,
+                language,
+                published,
+                tags,
+            } => {
+                let params = commands::articles::update::UpdateParams {
+                    title,
+                    content_file,
+                    language,
+                    published,
+                    tags,
+                };
+                commands::articles::update::run(&client, &collection, &id, params).await
+            }
+            ArticlesAction::Delete { id, collection } => {
+                commands::articles::delete::run(&client, &collection, &id).await
+            }
+            ArticlesAction::Move { id, collection, to } => {
+                commands::articles::move_article::run(&client, &collection, &id, &to).await
             }
         },
     }

--- a/src/models/article.rs
+++ b/src/models/article.rs
@@ -1,0 +1,64 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Article {
+    pub id: String,
+
+    #[serde(default)]
+    pub title: Option<serde_json::Value>,
+
+    #[serde(default)]
+    pub description: Option<serde_json::Value>,
+
+    #[serde(default)]
+    pub content: Option<serde_json::Value>,
+
+    #[serde(rename = "plainContent", default)]
+    pub plain_content: Option<serde_json::Value>,
+
+    #[serde(rename = "helpcenterCollection", default)]
+    pub helpcenter_collection: Option<String>,
+
+    #[serde(default)]
+    pub author: Option<serde_json::Value>,
+
+    #[serde(rename = "isDraft", default)]
+    pub is_draft: Option<bool>,
+
+    #[serde(default)]
+    pub tags: Option<Vec<String>>,
+
+    #[serde(rename = "targetAudience", default)]
+    pub target_audience: Option<String>,
+
+    #[serde(default)]
+    pub upvotes: Option<serde_json::Value>,
+
+    #[serde(default)]
+    pub lexorank: Option<String>,
+
+    #[serde(rename = "externalId", default)]
+    pub external_id: Option<String>,
+
+    #[serde(rename = "docId", default)]
+    pub doc_id: Option<u64>,
+
+    #[serde(rename = "sourceUsage", default)]
+    pub source_usage: Option<u64>,
+
+    #[serde(rename = "createdAt", default)]
+    pub created_at: Option<String>,
+
+    #[serde(rename = "updatedAt", default)]
+    pub updated_at: Option<String>,
+
+    /// Catch-all for fields we don't explicitly model yet.
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ArticleFilters {
+    pub limit: Option<u64>,
+    pub skip: Option<u64>,
+}

--- a/src/models/collection.rs
+++ b/src/models/collection.rs
@@ -1,0 +1,52 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Collection {
+    pub id: String,
+
+    #[serde(default)]
+    pub title: Option<serde_json::Value>,
+
+    #[serde(default)]
+    pub description: Option<serde_json::Value>,
+
+    #[serde(rename = "iconUrl", default)]
+    pub icon_url: Option<String>,
+
+    #[serde(default)]
+    pub parent: Option<String>,
+
+    #[serde(rename = "targetAudience", default)]
+    pub target_audience: Option<String>,
+
+    #[serde(rename = "articlesCount", default)]
+    pub articles_count: Option<u64>,
+
+    #[serde(rename = "subCollectionsCount", default)]
+    pub sub_collections_count: Option<u64>,
+
+    #[serde(default)]
+    pub lexorank: Option<String>,
+
+    #[serde(rename = "externalId", default)]
+    pub external_id: Option<String>,
+
+    #[serde(rename = "docId", default)]
+    pub doc_id: Option<u64>,
+
+    #[serde(rename = "createdAt", default)]
+    pub created_at: Option<String>,
+
+    #[serde(rename = "updatedAt", default)]
+    pub updated_at: Option<String>,
+
+    /// Catch-all for fields we don't explicitly model yet.
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CollectionFilters {
+    pub limit: Option<u64>,
+    pub skip: Option<u64>,
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,3 +1,4 @@
+pub mod article;
 pub mod collection;
 pub mod message;
 pub mod ticket;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,2 +1,3 @@
+pub mod collection;
 pub mod message;
 pub mod ticket;


### PR DESCRIPTION
## Summary

Adds help center management capabilities to the CLI — two new domains (collections and articles) with full CRUD, plus backfills missing `delete` operations on existing domains for API parity.

- **`delete()` request builder** on `GleapClient` (prerequisite for all delete operations)
- **Tickets delete**: `gleap tickets delete <ID>`
- **Messages delete**: `gleap messages delete <ID>`
- **Collections CRUD**: `gleap collections list/get/create/update/delete`
- **Articles CRUD + move**: `gleap articles list/get/create/update/delete/move` with language-key wrapping, `--content-file` for Tiptap JSON, and `--published` flag

## Implementation Details

- Follows the established 4-layer architecture (model → client → CLI → commands)
- Collections model uses `serde_json::Value` for `title`/`description` to handle localized objects
- Articles use nested URLs under `/helpcenter/collections/{id}/articles`
- Article `--title` and `--content-file` are wrapped in a language key (`--language` flag, default: `en`)
- All commands output pretty-printed JSON and respect `-v`/`-vv`/`-vvv` verbosity flags

## Closes

- #10 — `delete()` request builder
- #8 — tickets delete
- #9 — messages delete
- #6 — collections domain
- #7 — articles domain
- #11 — epic tracking issue

## Test plan

- [ ] `cargo build && cargo clippy -- -D warnings && cargo test` passes (verified locally)
- [ ] `gleap collections list` returns JSON array
- [ ] `gleap collections create --title "Test"` creates and returns collection
- [ ] `gleap articles list --collection <ID>` returns articles
- [ ] `gleap articles create --collection <ID> --title "Test" --content-file test.json` creates article
- [ ] `gleap articles move --collection <ID> <ARTICLE_ID> --to <TARGET>` moves article
- [ ] `gleap tickets delete <ID>` and `gleap messages delete <ID>` send DELETE requests
- [ ] Error handling: 401→Auth, 404→NotFound, invalid content file→clear error message